### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -31,6 +31,18 @@ class ItemsController < ApplicationController
       redirect_to @item
     else
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if current_user.id == @item.user_id
+      if @item.destroy
+        redirect_to root_path
+      else
+        redirect_to item_path(@item), alert: 'failed to delete'
+      end
+    else
+      redirect_to item_path(@item), alert: 'You are not authorized to delete this item'
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
         <%# <% else %>
           <%= link_to "商品の編集", edit_item_path(params[:id]), method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
-          <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+          <%= link_to "削除", item_path(@item) , data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？"}, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>


### PR DESCRIPTION
# What
商品削除ボタンのアクティブ化
# Why
商品削除機能実装のため
# Gyazo
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/072b3338020628fa08714e9a3a13fa3c


